### PR TITLE
BUILD-2946 Adapt typescript-test-sources (replace deprecated set-output)

### DIFF
--- a/src/ant-design/.github/workflows/preview-deploy.yml
+++ b/src/ant-design/.github/workflows/preview-deploy.yml
@@ -34,7 +34,7 @@ jobs:
       # Save PR id to output
       - name: save PR id
         id: pr
-        run: echo "::set-output name=id::$(<pr-id.txt)"
+        run: echo "id=$(<pr-id.txt)" >> "$GITHUB_OUTPUT"
 
       # Download site artifact
       - name: download site artifact
@@ -93,7 +93,7 @@ jobs:
       # Save PR id to output
       - name: save PR id
         id: pr
-        run: echo "::set-output name=id::$(<pr-id.txt)"
+        run: echo "id=$(<pr-id.txt)" >> "$GITHUB_OUTPUT"
 
       - name: The job has failed
         uses: actions-cool/maintain-one-comment@v2

--- a/src/ant-design/.github/workflows/ui-upload.yml
+++ b/src/ant-design/.github/workflows/ui-upload.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Save commit id
         id: commit
-        run: echo "::set-output name=id::$(<commit.txt)"
+        run: echo "id=$(<commit.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Download branch artifact
         uses: dawidd6/action-download-artifact@v2
@@ -41,7 +41,7 @@ jobs:
 
       - name: Save branch id
         id: branch
-        run: echo "::set-output name=id::$(<branch.txt)"
+        run: echo "id=$(<branch.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Download snapshots artifact
         uses: dawidd6/action-download-artifact@v2

--- a/src/desktop/.github/workflows/ci.yml
+++ b/src/desktop/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/src/searchkit/.github/workflows/cd.yml
+++ b/src/searchkit/.github/workflows/cd.yml
@@ -48,9 +48,9 @@ jobs:
           http_status_code=$(curl -LI $GET_API_URL -o /dev/null -w '%{http_code}\n' -s \
             -H "Authorization: token ${GITHUB_TOKEN}")
           if [ "$http_status_code" -ne "404" ] ; then
-            echo "::set-output name=exists_tag::true"
+            echo "exists_tag=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::set-output name=exists_tag::false"
+            echo "exists_tag=false" >> "$GITHUB_OUTPUT"
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# BUILD-2946 Adapt typescript-test-sources (replace deprecated set-output)

## Changes
* Remove deprecated call to set-ouput and replace it with github recommended way: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/