### PR TITLE
JS-1316 Add bun+react monorepo project sample

### DIFF
--- a/hs-template/apps/admin/package.json
+++ b/hs-template/apps/admin/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "@repo/admin",
+	"private": true,
+	"dependencies": {
+		"react": "catalog:",
+		"react-dom": "catalog:"
+	}
+}

--- a/hs-template/apps/admin/src/components/legacy-component.tsx
+++ b/hs-template/apps/admin/src/components/legacy-component.tsx
@@ -1,0 +1,82 @@
+// Importing PropTypes from "react" is considered deprecated starting at React version 15.5.
+import React, { PropTypes } from "react";
+// `render`, `hydrate` and `unmountComponentAtNode` from "react-dom" are considered deprecated starting at React version 18.0.
+import ReactDOM, { render, hydrate, unmountComponentAtNode } from "react-dom";
+// `renderToNodeStream` from "react-dom/server" is considered deprecated starting at React version 18.0.
+import ReactDOMServer, { renderToNodeStream } from "react-dom/server";
+
+interface LegacyComponentProps {
+	userId: string;
+	label: string;
+}
+
+interface LegacyComponentState {
+	count: number;
+	data: string | null;
+}
+
+export class LegacyComponent extends React.Component<
+	LegacyComponentProps,
+	LegacyComponentState
+> {
+	// Using `PropTypes` from the "react" package is considered deprecated starting at React version 15.5.
+	static propTypes = {
+		userId: PropTypes.string,
+		label: PropTypes.string,
+	};
+
+	constructor(props: LegacyComponentProps) {
+		super(props);
+		this.state = { count: 0, data: null };
+	}
+
+	// `componentWillMount` is considered deprecated starting at React version 16.9.
+	componentWillMount() {
+		this.setState({ data: `loading-${this.props.userId}` });
+	}
+
+	// `componentWillReceiveProps` is considered deprecated starting at React version 16.9.
+	componentWillReceiveProps(nextProps: LegacyComponentProps) {
+		if (nextProps.userId !== this.props.userId) {
+			this.setState({ count: 0 });
+		}
+	}
+
+	// `componentWillUpdate` is considered deprecated starting at React version 16.9.
+	componentWillUpdate(
+		nextProps: LegacyComponentProps,
+		nextState: LegacyComponentState,
+	) {
+		console.log("about to update", nextProps.userId, nextState.count);
+	}
+
+	render() {
+		return (
+			<div>
+				<span>{this.props.label}</span>
+				<span>{this.state.count}</span>
+			</div>
+		);
+	}
+}
+
+export function mountLegacy(container: HTMLElement) {
+	// `ReactDOM.render` / `render` is considered deprecated starting at React version 18.0.
+	ReactDOM.render(<LegacyComponent userId="1" label="hello" />, container);
+	render(<LegacyComponent userId="2" label="world" />, container);
+
+	// `ReactDOM.hydrate` / `hydrate` is considered deprecated starting at React version 18.0.
+	ReactDOM.hydrate(<LegacyComponent userId="3" label="ssr" />, container);
+	hydrate(<LegacyComponent userId="4" label="ssr" />, container);
+
+	// `ReactDOM.unmountComponentAtNode` / `unmountComponentAtNode` is considered deprecated starting at React version 18.0.
+	ReactDOM.unmountComponentAtNode(container);
+	unmountComponentAtNode(container);
+}
+
+export function streamLegacy() {
+	const element = <LegacyComponent userId="5" label="stream" />;
+	// `ReactDOMServer.renderToNodeStream` / `renderToNodeStream` is considered deprecated starting at React version 18.0.
+	ReactDOMServer.renderToNodeStream(element);
+	renderToNodeStream(element);
+}

--- a/hs-template/package.json
+++ b/hs-template/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "hs-template",
+	"private": true,
+	"packageManager": "bun@1.3.3",
+	"workspaces": {
+		"packages": ["apps/*"],
+		"catalog": {
+			"react": "17.0.2",
+			"react-dom": "17.0.2"
+		}
+	}
+}


### PR DESCRIPTION
# JS-1316 Add bun + React monorepo sample fixture

## Summary
- Adds `hs-template/`, a Bun monorepo sample (admin app + API + shared packages) that uses Bun catalog references (`"react": "catalog:"`) defined at the root `package.json`. This exercises the catalog-resolution path SonarJS gains on the `JS-1316` branch.
- The catalog pins `react` / `react-dom` to `17.0.2` — strictly between `>16.9.0` and `<18.0.0` — so deprecation gating can be verified at three tiers.
- `apps/admin/src/components/legacy-component.tsx` deliberately mixes deprecated APIs from three eras: pre-15.5 (`PropTypes`), 16.9 (`componentWillMount` / `componentWillReceiveProps` / `componentWillUpdate`), and 18.0 (`ReactDOM.render` / `hydrate` / `unmountComponentAtNode` / `renderToNodeStream`, both as namespace and named imports). Inline comments call out the version each API was deprecated in.

## Why
This fixture is the regression test for SonarJS rule `S6957` once Bun catalog support lands:

| | SonarJS master (no catalog support) | SonarJS `JS-1316` branch |
|---|---|---|
| Resolved React version | null → falls back to "latest" | `17.0.2` |
| 15.5 / 16.9 deprecations flagged | ✓ | ✓ |
| 18.0 deprecations flagged | ✓ (false positives at React 17) | ✗ (correctly silenced) |
| Issues raised on `legacy-component.tsx` | 12 | 4 |

## Test plan
- [ ] Symlink `hs-template/` into `SonarJS/its/sources/projects/`, register in `packages/ruling/projects.json`, add `hs-template.ruling.test.ts`
- [ ] `npx tsx --tsconfig packages/tsconfig.test.json --test packages/ruling/projects/hs-template.ruling.test.ts` on SonarJS `master` → expect 12 issues at lines 2, 4, 4, 4, 6, 34, 39, 46, 65, 69, 73, 80
- [ ] Same command on SonarJS `feature/JS-1316-support-bun-catalogs` → expect 4 issues at lines 2, 34, 39, 46
