### PR TITLE
Add Vue+TS edge-case fixtures to it-tools for JS-1499

### DIFF
--- a/it-tools/src/components/AutoResizeTextarea.vue
+++ b/it-tools/src/components/AutoResizeTextarea.vue
@@ -1,0 +1,13 @@
+<script lang="ts" setup>
+import { computed, ref } from 'vue'
+
+const props = defineProps<{ modelValue: string }>()
+
+const textarea = ref(<HTMLTextAreaElement | null>null)
+const charCount = computed(() => props.modelValue.length)
+</script>
+
+<template>
+  <textarea ref="textarea" :value="modelValue" />
+  <span>{{ charCount }} characters</span>
+</template>

--- a/it-tools/src/components/JsxRenderer.vue
+++ b/it-tools/src/components/JsxRenderer.vue
@@ -1,0 +1,12 @@
+<script lang="tsx">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  props: {
+    label: { type: String, required: true },
+  },
+  setup(props) {
+    return () => <span class="renderer-label">{props.label}</span>
+  },
+})
+</script>


### PR DESCRIPTION
Two small components exercising parser-option paths affected by the SonarJS JS-1499 ticket (Harden parser-option strategy):

- AutoResizeTextarea.vue: <script lang="ts"> with a TypeScript angle-bracket type assertion. Reproduces the JS-674 parsing failure before JS-1499 (JSX/TS ambiguity); parses cleanly after.

- JsxRenderer.vue: <script lang="tsx"> rendering JSX from setup(). Confirms TSX scripts continue to parse on the same path.